### PR TITLE
add support for https_proxy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,10 +50,14 @@ Assuming success, all methods trigger the callback with an object like the follo
 }
 ```
 
+## HTTPS Proxy
+Sending via an HTTP/HTTPS proxy is supported. Just set the environment variable `https_proxy` and it will be used when making requests to the API.
+
 ## Version History
 
 Version | Notes
 ------- | -----
+0.2.0   | Add support for HTTPS proxy.
 0.1.0   | Interface change, use new NASA APOD API
 0.0.1   | Initial release
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var superagent = require("superagent");
+require("superagent-proxy")(superagent);
 
 function quit(reason) {
   throw new Error(reason);
@@ -40,7 +41,7 @@ function randomDate() {
       current.getFullYear(),
       current.getMonth() + 1,
       current.getDate()
-    ].join("-"))
+    ].join("-"));
 
     current.setDate(current.getDate() + 1);
   }
@@ -68,9 +69,16 @@ var apod = module.exports = function apod() {
     date.getDate()
   ].join("-");
 
-  superagent
-    .get("https://api.data.gov/nasa/planetary/apod")
-    .query({ concept_tags: "True", api_key: apod.apiKey, date: date })
+  var proxy = process.env.https_proxy;
+
+  var req = superagent
+    .get("https://api.data.gov/nasa/planetary/apod");
+
+  if (proxy) {
+    req = req.proxy(proxy);
+  }
+
+  req.query({ concept_tags: "True", api_key: apod.apiKey, date: date })
     .end(function(err, res) {
       var body = res.body;
 
@@ -81,7 +89,7 @@ var apod = module.exports = function apod() {
 
       callback(null, body);
     });
-}
+};
 
 apod.apiKey = null;
 

--- a/package.json
+++ b/package.json
@@ -3,15 +3,13 @@
   "version": "0.1.0",
   "description": "Wrapper around NASA's APOD API",
   "author": "Andrew Stewart <andrew@stwrt.ca> (http://andrew.stwrt.ca)",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/stewart/apod.js"
   },
-
   "license": "MIT",
-
   "dependencies": {
-    "superagent": "1.2.0"
+    "superagent": "1.2.0",
+    "superagent-proxy": "^1.0.0"
   }
 }


### PR DESCRIPTION
Hello!

Thanks for putting together this neat package :)

This PR adds support for HTTPs proxies via the `https_proxy` environment variable. It uses [superagent-proxy](https://github.com/TooTallNate/superagent-proxy) to accomplish this.

Cheers!
